### PR TITLE
Change e-mail to new AUTh alias

### DIFF
--- a/contact.md
+++ b/contact.md
@@ -8,7 +8,7 @@ permalink: /contact/
 
 ## Contact details
 
-|e-mail|[acmauthchapter@gmail.com](mailto:acmauthchapter@gmail.com)|
+|e-mail|[acmchapter@auth.gr](mailto:acmchapter@auth.gr)|
 |Facebook page|[ACM Student Chapter AUTH](https://www.facebook.com/acmauth/?ref=aymt_homepage_panel)|
 |Twitter page|[@acm_auth](https://twitter.com/acm_auth)|
 |Github page|[@acmauth](https://github.com/acmauth)|


### PR DESCRIPTION
## Description

New e-mail alias from [IT.auth](https://it.auth.gr/el) is here.
Change the info in the contact page to the new e-mail.
